### PR TITLE
implementing audiograph and nodes for queuing multiple outputs

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,11 +18,13 @@ tauri-build = { version = "1.0.0-rc.5", features = [] }
 chrono = "0.4"
 futures = "0.3.21"
 rodio = { version = "*" }
-pulse = { version = "2.26.*", package= "libpulse-binding" }
-psimple = { version="2.25.*", package="libpulse-simple-binding" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "1.0.0-rc.5", features = ["api-all"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+pulse = { version = "2.26.*", package= "libpulse-binding" }
+psimple = { version="2.25.*", package="libpulse-simple-binding" }
 
 [features]
 # by default Tauri runs in production mode

--- a/backend/src/daw/daw.rs
+++ b/backend/src/daw/daw.rs
@@ -145,9 +145,10 @@ pub fn run_playlist(state_ref: &sync::Arc<state::InnerState>) {
 
 pub fn pause_playlist(state: tauri::State<'_, sync::Arc<state::InnerState>>) {
   println!("pausing playlist");
-  state
-    .playlist_is_playing
-    .store(false, atomic::Ordering::SeqCst);
+
+  // pause the audiograph, clearing all start times
+  let mut audiograph_ref = state.playlist_audiograph.lock().unwrap();
+  audiograph_ref.pause();
 
   // reset playlist to 0 beats
   state
@@ -156,6 +157,11 @@ pub fn pause_playlist(state: tauri::State<'_, sync::Arc<state::InnerState>>) {
   state
     .playlist_total_beats
     .store(0, atomic::Ordering::SeqCst);
+  
+  // set playlist state to paused
+  state
+    .playlist_is_playing
+    .store(false, atomic::Ordering::SeqCst);
 }
 
 pub fn start_playlist(state: tauri::State<'_, sync::Arc<state::InnerState>>) {

--- a/backend/src/daw/daw_core/audiograph.rs
+++ b/backend/src/daw/daw_core/audiograph.rs
@@ -1,0 +1,144 @@
+use std::thread;
+use std::time;
+use std::marker;
+use futures;
+use crate::daw;
+
+#[derive(Clone)]
+pub struct AudioNode {
+  id: u64,
+  sample_path: String,
+  start_time: Option<u64>,
+  start_offset: u64
+}
+
+impl AudioNode {
+  pub fn new(
+    id: u64,
+    sample_path: String,
+    start_offset: u64
+  ) -> Self {
+    AudioNode {
+      id,
+      sample_path,
+      start_time: None,
+      start_offset
+    }
+  }
+
+  // calculate and set a node's (real) start time in the playlist
+  pub fn set_start_time(&mut self, start_time: u64) {
+    self.start_time = Some(start_time + self.start_offset);
+  }
+}
+
+pub struct AudioGraph<'a> {
+  nodes: std::vec::Vec<AudioNode>,
+  running: bool,
+  started_time: Option<u64>,
+  current_offset: u64,
+  phantom: marker::PhantomData<&'a str>,
+}
+
+impl AudioGraph<'static> {
+  pub fn new() -> Self {
+    AudioGraph {
+      nodes: std::vec::Vec::<AudioNode>::new(),
+      running: false,
+      started_time: None,
+      current_offset: 0,
+      phantom: marker::PhantomData,
+    }
+  }
+
+  // initialize the audiograph with a 
+  // start time (from the playlist)
+  pub fn init(&mut self, start_time: u64) {
+    if self.nodes.len() == 0 { return; }
+
+    for node in self.nodes.as_mut_slice() {
+      node.set_start_time(start_time);
+    }
+
+    self.started_time = Some(start_time);
+    self.running = true;
+  }
+
+  // run graph and schedule nodes to be played
+  // n milliseconds in advance
+  pub fn run_for(&self, time_ms: u64) {
+    if self.nodes.len() == 0 {
+      println!("Tried to run audio graph. No nodes in graph!");
+      return;
+    }
+    
+    // construct a threadpool
+    let pool = daw::daw_core::threadpool::ThreadPool::new(4);
+
+    // get starting index of nodes within this time slice
+    let idx_start = self.nodes.iter()
+      .position(|node| node.start_offset >= self.current_offset).unwrap();
+
+    // get last index of nodes within this time slice
+    let idx_end = self.nodes.iter().rev()
+      .position(|node| (node.start_offset + time_ms) > self.current_offset).unwrap() - 1;
+
+    let self_arc = std::sync::Arc::new(std::sync::Mutex::new(self));
+
+    // schedule samples within this timeslice to play
+    // let nodes: std::sync::Arc<std::sync::Mutex<std::vec::Vec<AudioNode<'static>>>> = std::sync::Arc::new(std::sync::Mutex::new(self.nodes));
+    // let current_offset = std::sync::atomic::AtomicU64::new(self.current_offset);
+
+    let slice = self_arc.lock().unwrap().nodes[idx_start..idx_end].to_vec();
+    for node in slice {
+      let sample_path = std::sync::Arc::new(std::sync::Mutex::new(node.sample_path));
+      let start_offset = std::sync::Arc::new(std::sync::Mutex::new(node.start_offset));
+      let current_offset = std::sync::Arc::new(std::sync::Mutex::new(self_arc.lock().unwrap().current_offset));
+      // let current_offset = current_offset.load(std::sync::atomic::Ordering::SeqCst).clone();
+
+      thread::spawn(move || {
+        // calculate time until sample is played
+        let dur = *start_offset.lock().unwrap() - *current_offset.lock().unwrap();
+        
+        // sleep this thread until it's time to play the sample, then play it
+        thread::sleep(time::Duration::from_millis(dur));
+        futures::executor::block_on(daw::play_sample(&*sample_path.lock().unwrap()));
+      });
+    }
+  }
+
+  // add nodes to the audio graph and sort the graph by
+  // offset start time
+  pub fn add_node(&mut self, node: AudioNode) {
+    self.nodes.push(node);
+    self.nodes.sort_unstable_by(|a, b| a.start_offset.cmp(&b.start_offset));
+  }
+
+  // construct an audio node from a sample path and start offset,
+  // and add it to the audio graph
+  // returns the id of the constructed node
+  pub fn construct_and_add_node(
+    &mut self,
+    sample_path: String,
+    start_offset: u64
+  ) -> u64 {
+    let id = self.nodes.len().clone().try_into().unwrap();
+    let node = AudioNode::new(
+      id,
+      sample_path,
+      start_offset
+    );
+
+    self.add_node(node);
+    id
+  }
+
+  // get the length in milliseconds from the start 
+  // of the playlist to the last node in the graph, 
+  // not including the length of node (but should in the future)
+  // (does not include padding added by the playlist)
+  pub fn len_real_in_ms(self) -> u64 {
+    if self.nodes.len() == 0 { return 0; }
+    self.nodes.last().unwrap().start_offset
+  }
+}

--- a/backend/src/daw/daw_core/drivers.rs
+++ b/backend/src/daw/daw_core/drivers.rs
@@ -1,8 +1,12 @@
 use rodio::cpal::{self, traits::HostTrait};
 use rodio::{self, DeviceTrait};
+
+#[cfg(target_os = "linux")]
 use pulse;
+#[cfg(target_os = "linux")]
 use psimple;
 
+#[cfg(target_os = "linux")]
 pub fn configure_audio_driver() {
   if cfg!(target_os = "linux") {
     // configure PulseAudio sound server

--- a/backend/src/daw/daw_core/drivers.rs
+++ b/backend/src/daw/daw_core/drivers.rs
@@ -6,31 +6,6 @@ use pulse;
 #[cfg(target_os = "linux")]
 use psimple;
 
-#[cfg(target_os = "linux")]
-pub fn configure_audio_driver() {
-  if cfg!(target_os = "linux") {
-    // configure PulseAudio sound server
-    let spec = pulse::sample::Spec {
-      format: pulse::sample::Format::S24NE,
-      channels: 2,
-      rate: 44_100
-    };
-
-    let sink = psimple::Simple::new(
-      None,
-      "dawesome",
-      pulse::stream::Direction::Playback,
-      None,
-      "dawesome output",
-      &spec,
-      None,
-      None
-    ).unwrap();
-
-    
-  }
-}
-
 pub fn print_device_drivers() -> Result<(), String> {
   println!("Supported hosts:\n  {:?}", cpal::ALL_HOSTS);
   let available_hosts = cpal::available_hosts();
@@ -97,6 +72,7 @@ pub fn print_device_drivers() -> Result<(), String> {
       }
     }
   }
+
   Ok(())
 }
 

--- a/backend/src/daw/daw_core/mod.rs
+++ b/backend/src/daw/daw_core/mod.rs
@@ -1,8 +1,10 @@
+pub(crate) mod audiograph;
 pub(crate) mod drivers;
 pub(crate) mod threadpool;
 pub(crate) mod timer;
 pub(crate) mod timing;
 
+pub use audiograph::*;
 pub use drivers::*;
 pub use threadpool::*;
 pub use timer::*;

--- a/backend/src/daw/state/state.rs
+++ b/backend/src/daw/state/state.rs
@@ -1,6 +1,7 @@
 use std::sync;
 use std::sync::atomic;
 use crate::daw::timing;
+use crate::daw;
 
 pub struct InnerState {
   pub global_tempo_bpm: sync::Arc<sync::Mutex<f32>>,
@@ -9,6 +10,7 @@ pub struct InnerState {
   pub playlist_total_beats: atomic::AtomicU64,
   pub playlist_current_beat: atomic::AtomicU16,
   pub playlist_time_signature: sync::Arc<sync::Mutex<timing::TimeSignature>>,
+  pub playlist_audiograph: sync::Arc<sync::Mutex<daw::AudioGraph<'static>>>,
   pub metronome_enabled: atomic::AtomicBool,
 }
 
@@ -28,6 +30,7 @@ impl InnerState {
         numerator: 4,
         denominator: 4
       })),
+      playlist_audiograph: sync::Arc::new(sync::Mutex::new(daw::AudioGraph::new())),
       metronome_enabled: atomic::AtomicBool::from(true),
     }
   }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -106,12 +106,11 @@ fn add_audiograph_node(
   let id = state.playlist_audiograph.lock().unwrap()
     .construct_and_add_node(sample_path, start_offset);
   
+  // returns the id of the new node
   Ok(id)
 }
 
 fn main() {
-  // daw::print_device_drivers();
-
   tauri::Builder::default()
     .setup(app::setup)
     .menu(app::build_menu())

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -97,6 +97,18 @@ fn get_audio_drivers() -> Result<Vec<String>, String> {
   Ok(daw::drivers::get_sound_host_names())
 }
 
+#[tauri::command]
+fn add_audiograph_node(
+  state: tauri::State<'_, sync::Arc<daw::InnerState>>,
+  sample_path: String,
+  start_offset: u64
+) -> Result<u64, String> {
+  let id = state.playlist_audiograph.lock().unwrap()
+    .construct_and_add_node(sample_path, start_offset);
+  
+  Ok(id)
+}
+
 fn main() {
   // daw::print_device_drivers();
 


### PR DESCRIPTION
- adds `AudioGraph` and `AudioNode` structs for modelling compositions of samples that can be played in a timeline/arrangement view
- adds functions for adding nodes to audiograph by sample:

```rs
AudioGraph.construct_and_add_node(
  &mut self,
  sample_path: String,
  start_offset: u64
) -> u64
```

- adds playlist audiograph to state
- adds tauri method for adding audio nodes from the frontend
  - ids are automatically generated
  - node playtime is automatically calculated when the playlist is toggled
- conditional dependencies for compiling cross-platform
